### PR TITLE
feat: add dataset governance validation and provenance drift tooling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Docs and release artifact checks
         run: |
           ./scripts/check_repo_docs.sh
+      - name: Validate dataset manifest
+        run: |
+          go run cmd/manifest/main.go datasets/manifest.json
       - name: Run tests with coverage
         run: |
           go test -coverprofile=coverage.out ./...

--- a/cmd/drift/main.go
+++ b/cmd/drift/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/SamyRai/bank-data/internal/drift"
+)
+
+func main() {
+	if len(os.Args) < 4 {
+		fmt.Println("Usage: drift_report <old_dataset.csv> <new_dataset.csv> <country_code>")
+		os.Exit(1)
+	}
+	oldPath := os.Args[1]
+	newPath := os.Args[2]
+	countryCode := os.Args[3]
+
+	oldData, err := drift.ParseCSV(oldPath, countryCode)
+	if err != nil {
+		fmt.Printf("Error reading old dataset: %v\n", err)
+		os.Exit(1)
+	}
+
+	newData, err := drift.ParseCSV(newPath, countryCode)
+	if err != nil {
+		fmt.Printf("Error reading new dataset: %v\n", err)
+		os.Exit(1)
+	}
+
+	report := drift.CalculateDrift(oldData, newData)
+
+	reportJSON, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fmt.Printf("Error generating report JSON: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile("drift_report.json", reportJSON, 0644); err != nil {
+		fmt.Printf("Error writing report file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Drift report written to drift_report.json")
+}

--- a/cmd/drift/main.go
+++ b/cmd/drift/main.go
@@ -37,7 +37,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := os.WriteFile("drift_report.json", reportJSON, 0644); err != nil {
+	if err := os.WriteFile("drift_report.json", reportJSON, 0600); err != nil {
 		fmt.Printf("Error writing report file: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/manifest/main.go
+++ b/cmd/manifest/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/SamyRai/bank-data/internal/manifest"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: validate_manifest <path/to/manifest.json>")
+		os.Exit(1)
+	}
+	manifestPath := os.Args[1]
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		fmt.Printf("Error reading manifest: %v\n", err)
+		os.Exit(1)
+	}
+
+	errs := manifest.ValidateManifest(data, manifest.CalculateChecksum)
+	if len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Println(e)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println("Manifest validation successful")
+}

--- a/cmd/manifest/main.go
+++ b/cmd/manifest/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/SamyRai/bank-data/internal/manifest"
 )
@@ -12,8 +14,13 @@ func main() {
 		fmt.Println("Usage: validate_manifest <path/to/manifest.json>")
 		os.Exit(1)
 	}
-	manifestPath := os.Args[1]
+	manifestPath, err := sanitizeRelativePath(os.Args[1])
+	if err != nil {
+		fmt.Printf("Invalid manifest path: %v\n", err)
+		os.Exit(1)
+	}
 
+	// #nosec G304 -- path is sanitized to a repository-relative path before read.
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		fmt.Printf("Error reading manifest: %v\n", err)
@@ -29,4 +36,21 @@ func main() {
 	}
 
 	fmt.Println("Manifest validation successful")
+}
+
+func sanitizeRelativePath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+
+	clean := filepath.Clean(trimmed)
+	if filepath.IsAbs(clean) {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path must stay within repository")
+	}
+
+	return clean, nil
 }

--- a/datasets/manifest.json
+++ b/datasets/manifest.json
@@ -1,33 +1,39 @@
 {
   "policy_version": 1,
-  "updated_at": "2026-03-08",
+  "updated_at": "2026-03-08T12:00:00Z",
   "datasets": [
     {
       "id": "iban-registry",
       "path": "datasets/iban-registry.txt",
       "format": "tab-separated text",
       "source": "SWIFT IBAN Registry",
+      "source_url": "https://www.swift.com/standards/data-standards/iban",
       "version_date": "2026-03-07",
       "license": "source terms apply",
-      "checksum": "untracked"
+      "checksum": "9b6a205fa9b48f701f086ecef11e9dd99b1bed9261cb9f50e5ea6906f0855732",
+      "generation_timestamp": "2026-03-08T12:00:00Z"
     },
     {
       "id": "de-blz-bic",
       "path": "datasets/blz_bic.csv",
       "format": "fixed-width text",
       "source": "Deutsche Bundesbank",
+      "source_url": "https://www.bundesbank.de/en/tasks/payment-systems/services-for-banks-and-other-payment-service-providers/bank-sort-codes-615696",
       "version_date": "2026-03-07",
       "license": "source terms apply",
-      "checksum": "untracked"
+      "checksum": "90161201ea79892b7311bac9a29d57dac5a794780708f9c68215a4be12adc598",
+      "generation_timestamp": "2026-03-08T12:00:00Z"
     },
     {
       "id": "fixtures-fr-at-nl",
       "path": "testdata/bankregistry/*.csv",
       "format": "csv",
       "source": "local deterministic fixtures",
+      "source_url": "local",
       "version_date": "2026-03-08",
       "license": "MIT",
-      "checksum": "not_applicable"
+      "checksum": "f6a4886b5426491632778502854e0464f7858910670016f74dfd95f87b0710d8",
+      "generation_timestamp": "2026-03-08T12:00:00Z"
     }
   ]
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,12 +39,15 @@ go test -coverprofile=coverage.out ./... && ./scripts/check_coverage.sh
 Country metadata is generated from `datasets/iban-registry.txt`.
 
 ```sh
-# regenerate internal/countrymeta/registry.go
-go generate ./...
+# fetch the latest registry and regenerate internal/countrymeta/registry.go
+./scripts/generate_registry.sh
 
-# run focused IBAN checks after regeneration
+# optionally validate the new manifest and run focused IBAN checks
+go run cmd/manifest/main.go datasets/manifest.json
 go test ./pkg/iban
 ```
+
+When regenerating the registry from a new upstream SWIFT update, remember to update the `checksum` and `generation_timestamp` fields for the `iban-registry` dataset in `datasets/manifest.json`. The generator outputs deterministic code (ordered and `go fmt` applied) to prevent noisy diffs.
 
 ## Contribution Rules
 

--- a/gen/ibanmeta/ibanmeta.go
+++ b/gen/ibanmeta/ibanmeta.go
@@ -5,6 +5,7 @@ package ibanmeta
 
 import (
 	"fmt"
+	"go/format"
 	"os"
 	"regexp"
 	"sort"
@@ -179,7 +180,13 @@ func GenerateRegistry(txtPath string) ([]byte, error) {
 		buf.WriteString("\t\t},\n")
 	}
 	buf.WriteString("\t}\n}\n")
-	return []byte(buf.String()), nil
+
+	formatted, err := format.Source([]byte(buf.String()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to format generated code: %v", err)
+	}
+
+	return formatted, nil
 }
 
 // swiftToGoRegex converts SWIFT/IBAN regex notation to Go regex.

--- a/gen/ibanmeta/ibanmeta.go
+++ b/gen/ibanmeta/ibanmeta.go
@@ -183,7 +183,7 @@ func GenerateRegistry(txtPath string) ([]byte, error) {
 
 	formatted, err := format.Source([]byte(buf.String()))
 	if err != nil {
-		return nil, fmt.Errorf("failed to format generated code: %v", err)
+		return nil, fmt.Errorf("failed to format generated code: %w", err)
 	}
 
 	return formatted, nil

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -1,0 +1,116 @@
+package drift
+
+import (
+	"bufio"
+	"os"
+	"sort"
+	"strings"
+)
+
+// DriftReport represents the output JSON for a drift report.
+type DriftReport struct {
+	CountryChanges   map[string]int      `json:"country_changes"`
+	AddedBankCodes   map[string][]string `json:"added_bank_codes"`
+	RemovedBankCodes map[string][]string `json:"removed_bank_codes"`
+}
+
+func CalculateDrift(oldData, newData map[string]map[string]bool) DriftReport {
+	report := DriftReport{
+		CountryChanges:   make(map[string]int),
+		AddedBankCodes:   make(map[string][]string),
+		RemovedBankCodes: make(map[string][]string),
+	}
+
+	// Compare old to new to find removed codes
+	for country, codes := range oldData {
+		for code := range codes {
+			if _, ok := newData[country]; !ok {
+				report.RemovedBankCodes[country] = append(report.RemovedBankCodes[country], code)
+				report.CountryChanges[country]--
+			} else if _, ok := newData[country][code]; !ok {
+				report.RemovedBankCodes[country] = append(report.RemovedBankCodes[country], code)
+				report.CountryChanges[country]--
+			}
+		}
+	}
+
+	// Compare new to old to find added codes
+	for country, codes := range newData {
+		if _, ok := oldData[country]; !ok {
+			for code := range codes {
+				report.AddedBankCodes[country] = append(report.AddedBankCodes[country], code)
+				report.CountryChanges[country]++
+			}
+		} else {
+			for code := range codes {
+				if _, ok := oldData[country][code]; !ok {
+					report.AddedBankCodes[country] = append(report.AddedBankCodes[country], code)
+					report.CountryChanges[country]++
+				}
+			}
+		}
+	}
+
+	// Calculate net country changes (remove entries with 0 change)
+	for country, change := range report.CountryChanges {
+		if change == 0 {
+			delete(report.CountryChanges, country)
+		}
+	}
+
+	// Sort slices for deterministic output
+	for _, v := range report.AddedBankCodes {
+		sort.Strings(v)
+	}
+	for _, v := range report.RemovedBankCodes {
+		sort.Strings(v)
+	}
+
+	return report
+}
+
+func ParseCSV(path string, defaultCountry string) (map[string]map[string]bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data := make(map[string]map[string]bool)
+	scanner := bufio.NewScanner(file)
+
+	// Assume first line is header
+	if scanner.Scan() {
+		_ = scanner.Text()
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Split(line, ",")
+
+		// Typically our csv looks like: BankCode, BIC, BankName
+		// If it's a generic CSV with Country first, then use it
+		var country, code string
+		if len(parts) >= 3 {
+			// This could be our standard registry format, or something else.
+			// Let's assume standard format BankCode is parts[0]
+			code = strings.TrimSpace(parts[0])
+			country = defaultCountry
+
+			// If it looks like it has a country prefix: "AT,12345,..."
+			if len(parts[0]) == 2 && parts[0] == strings.ToUpper(parts[0]) {
+				country = strings.TrimSpace(parts[0])
+				code = strings.TrimSpace(parts[1])
+			}
+
+			if country != "" && code != "" {
+				if data[country] == nil {
+					data[country] = make(map[string]bool)
+				}
+				data[country][code] = true
+			}
+		}
+	}
+
+	return data, scanner.Err()
+}

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -2,7 +2,9 @@ package drift
 
 import (
 	"bufio"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -70,7 +72,13 @@ func CalculateDrift(oldData, newData map[string]map[string]bool) DriftReport {
 }
 
 func ParseCSV(path string, defaultCountry string) (map[string]map[string]bool, error) {
-	file, err := os.Open(path)
+	safePath, err := sanitizeRelativePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// #nosec G304 -- input path is sanitized to a repository-relative path.
+	file, err := os.Open(safePath)
 	if err != nil {
 		return nil, err
 	}
@@ -113,4 +121,21 @@ func ParseCSV(path string, defaultCountry string) (map[string]map[string]bool, e
 	}
 
 	return data, scanner.Err()
+}
+
+func sanitizeRelativePath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+
+	clean := filepath.Clean(trimmed)
+	if filepath.IsAbs(clean) {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path must stay within repository")
+	}
+
+	return clean, nil
 }

--- a/internal/drift/drift_test.go
+++ b/internal/drift/drift_test.go
@@ -1,0 +1,73 @@
+package drift
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCalculateDrift(t *testing.T) {
+	oldData := map[string]map[string]bool{
+		"AT": {
+			"12345": true,
+			"67890": true,
+		},
+		"FR": {
+			"11111": true,
+		},
+	}
+
+	newData := map[string]map[string]bool{
+		"AT": {
+			"12345": true, // Kept
+			// "67890" removed
+		},
+		"FR": {
+			"11111": true, // Kept
+			"22222": true, // Added
+		},
+		"NL": {
+			"99999": true, // Added
+		},
+	}
+
+	expectedReport := DriftReport{
+		CountryChanges: map[string]int{
+			"AT": -1,
+			"FR": 1,
+			"NL": 1,
+		},
+		AddedBankCodes: map[string][]string{
+			"FR": {"22222"},
+			"NL": {"99999"},
+		},
+		RemovedBankCodes: map[string][]string{
+			"AT": {"67890"},
+		},
+	}
+
+	report := CalculateDrift(oldData, newData)
+
+	if !reflect.DeepEqual(report, expectedReport) {
+		t.Errorf("CalculateDrift() mismatch.\nExpected: %v\nGot: %v", expectedReport, report)
+	}
+}
+
+func TestCalculateDrift_NoChange(t *testing.T) {
+	data := map[string]map[string]bool{
+		"AT": {
+			"12345": true,
+		},
+	}
+
+	expectedReport := DriftReport{
+		CountryChanges:   make(map[string]int),
+		AddedBankCodes:   make(map[string][]string),
+		RemovedBankCodes: make(map[string][]string),
+	}
+
+	report := CalculateDrift(data, data)
+
+	if !reflect.DeepEqual(report, expectedReport) {
+		t.Errorf("CalculateDrift() mismatch.\nExpected: %v\nGot: %v", expectedReport, report)
+	}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -136,7 +137,7 @@ func CalculateChecksum(pattern string) (string, error) {
 		if _, err := io.Copy(hash, file); err != nil {
 			closeErr := file.Close()
 			if closeErr != nil {
-				return "", fmt.Errorf("copy failed: %w (close failed: %v)", err, closeErr)
+				return "", fmt.Errorf("copy and close failed: %w", errors.Join(err, closeErr))
 			}
 			return "", err
 		}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -38,16 +38,16 @@ func ValidateManifest(data []byte, calculateChecksumFunc func(string) (string, e
 	var errs []error
 	var manifest Manifest
 	if err := json.Unmarshal(data, &manifest); err != nil {
-		return []error{fmt.Errorf("error parsing manifest JSON: %v", err)}
+		return []error{fmt.Errorf("error parsing manifest JSON: %w", err)}
 	}
 
 	if manifest.PolicyVersion <= 0 {
-		errs = append(errs, fmt.Errorf("Missing or invalid policy_version"))
+		errs = append(errs, fmt.Errorf("missing or invalid policy_version"))
 	}
 	if manifest.UpdatedAt == "" {
-		errs = append(errs, fmt.Errorf("Missing updated_at"))
+		errs = append(errs, fmt.Errorf("missing updated_at"))
 	} else if _, err := time.Parse(time.RFC3339, manifest.UpdatedAt); err != nil {
-		errs = append(errs, fmt.Errorf("Invalid updated_at format, must be RFC3339"))
+		errs = append(errs, fmt.Errorf("invalid updated_at format, must be RFC3339"))
 	}
 
 	seenDatasetIDs := make(map[string]struct{}, len(manifest.Datasets))
@@ -95,7 +95,7 @@ func ValidateManifest(data []byte, calculateChecksumFunc func(string) (string, e
 			// Verify checksum matches actual files only when both path and checksum shape are valid.
 			actualChecksum, err := calculateChecksumFunc(ds.Path)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("Dataset %s: Could not calculate checksum for %s: %v", ds.ID, ds.Path, err))
+				errs = append(errs, fmt.Errorf("Dataset %s: Could not calculate checksum for %s: %w", ds.ID, ds.Path, err))
 			} else if actualChecksum != ds.Checksum {
 				errs = append(errs, fmt.Errorf("Dataset %s: Checksum mismatch for %s. Expected %s, got %s", ds.ID, ds.Path, ds.Checksum, actualChecksum))
 			}
@@ -136,7 +136,7 @@ func CalculateChecksum(pattern string) (string, error) {
 		if _, err := io.Copy(hash, file); err != nil {
 			closeErr := file.Close()
 			if closeErr != nil {
-				return "", fmt.Errorf("copy failed: %v (close failed: %v)", err, closeErr)
+				return "", fmt.Errorf("copy failed: %w (close failed: %v)", err, closeErr)
 			}
 			return "", err
 		}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,136 @@
+package manifest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Manifest struct {
+	PolicyVersion int       `json:"policy_version"`
+	UpdatedAt     string    `json:"updated_at"`
+	Datasets      []Dataset `json:"datasets"`
+}
+
+type Dataset struct {
+	ID                  string `json:"id"`
+	Path                string `json:"path"`
+	Format              string `json:"format"`
+	Source              string `json:"source"`
+	SourceURL           string `json:"source_url"`
+	VersionDate         string `json:"version_date"`
+	License             string `json:"license"`
+	Checksum            string `json:"checksum"`
+	GenerationTimestamp string `json:"generation_timestamp"`
+}
+
+var checksumSHA256Regex = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+func ValidateManifest(data []byte, calculateChecksumFunc func(string) (string, error)) []error {
+	var errs []error
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return []error{fmt.Errorf("error parsing manifest JSON: %v", err)}
+	}
+
+	if manifest.PolicyVersion <= 0 {
+		errs = append(errs, fmt.Errorf("Missing or invalid policy_version"))
+	}
+	if manifest.UpdatedAt == "" {
+		errs = append(errs, fmt.Errorf("Missing updated_at"))
+	} else if _, err := time.Parse(time.RFC3339, manifest.UpdatedAt); err != nil {
+		errs = append(errs, fmt.Errorf("Invalid updated_at format, must be RFC3339"))
+	}
+
+	seenDatasetIDs := make(map[string]struct{}, len(manifest.Datasets))
+	for i, ds := range manifest.Datasets {
+		if ds.ID == "" {
+			errs = append(errs, fmt.Errorf("Dataset %d: Missing id", i))
+		} else {
+			if _, exists := seenDatasetIDs[ds.ID]; exists {
+				errs = append(errs, fmt.Errorf("Dataset %s: Duplicate id", ds.ID))
+			}
+			seenDatasetIDs[ds.ID] = struct{}{}
+		}
+		if strings.TrimSpace(ds.Path) == "" {
+			errs = append(errs, fmt.Errorf("Dataset %s: Missing path", ds.ID))
+		}
+		if strings.TrimSpace(ds.Format) == "" {
+			errs = append(errs, fmt.Errorf("Dataset %s: Missing format", ds.ID))
+		}
+		if strings.TrimSpace(ds.Source) == "" {
+			errs = append(errs, fmt.Errorf("Dataset %s: Missing source", ds.ID))
+		}
+		if ds.SourceURL == "" {
+			errs = append(errs, fmt.Errorf("Dataset %s: Missing source_url", ds.ID))
+		}
+		if ds.License == "" {
+			errs = append(errs, fmt.Errorf("Dataset %s: Missing license", ds.ID))
+		}
+		if ds.VersionDate == "" {
+			errs = append(errs, fmt.Errorf("Dataset %s: Missing version_date", ds.ID))
+		} else if _, err := time.Parse("2006-01-02", ds.VersionDate); err != nil {
+			errs = append(errs, fmt.Errorf("Dataset %s: Invalid version_date format, must be YYYY-MM-DD", ds.ID))
+		}
+		if !checksumSHA256Regex.MatchString(ds.Checksum) {
+			errs = append(errs, fmt.Errorf("Dataset %s: Invalid checksum '%s'", ds.ID, ds.Checksum))
+		}
+		if ds.GenerationTimestamp == "" {
+			errs = append(errs, fmt.Errorf("Dataset %s: Missing generation_timestamp", ds.ID))
+		} else {
+			if _, err := time.Parse(time.RFC3339, ds.GenerationTimestamp); err != nil {
+				errs = append(errs, fmt.Errorf("Dataset %s: Invalid generation_timestamp format, must be RFC3339", ds.ID))
+			}
+		}
+
+		if strings.TrimSpace(ds.Path) != "" && checksumSHA256Regex.MatchString(ds.Checksum) {
+			// Verify checksum matches actual files only when both path and checksum shape are valid.
+			actualChecksum, err := calculateChecksumFunc(ds.Path)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("Dataset %s: Could not calculate checksum for %s: %v", ds.ID, ds.Path, err))
+			} else if actualChecksum != ds.Checksum {
+				errs = append(errs, fmt.Errorf("Dataset %s: Checksum mismatch for %s. Expected %s, got %s", ds.ID, ds.Path, ds.Checksum, actualChecksum))
+			}
+		}
+	}
+	return errs
+}
+
+func CalculateChecksum(pattern string) (string, error) {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no files found matching pattern")
+	}
+	sort.Strings(matches)
+
+	// For consistent hashing of multiple files, sort by path and include file boundaries.
+	hash := sha256.New()
+	for _, match := range matches {
+		_, _ = io.WriteString(hash, match)
+		_, _ = hash.Write([]byte{0})
+
+		file, err := os.Open(match)
+		if err != nil {
+			return "", err
+		}
+		if _, err := io.Copy(hash, file); err != nil {
+			file.Close()
+			return "", err
+		}
+		file.Close()
+		_, _ = hash.Write([]byte{0})
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -105,6 +105,10 @@ func ValidateManifest(data []byte, calculateChecksumFunc func(string) (string, e
 }
 
 func CalculateChecksum(pattern string) (string, error) {
+	if err := validateSafeRelativePath(pattern); err != nil {
+		return "", fmt.Errorf("invalid checksum path pattern: %w", err)
+	}
+
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		return "", err
@@ -117,20 +121,47 @@ func CalculateChecksum(pattern string) (string, error) {
 	// For consistent hashing of multiple files, sort by path and include file boundaries.
 	hash := sha256.New()
 	for _, match := range matches {
+		if err := validateSafeRelativePath(match); err != nil {
+			return "", fmt.Errorf("invalid matched dataset path %q: %w", match, err)
+		}
+
 		_, _ = io.WriteString(hash, match)
 		_, _ = hash.Write([]byte{0})
 
+		// #nosec G304 -- match values are constrained to sanitized repository-relative paths.
 		file, err := os.Open(match)
 		if err != nil {
 			return "", err
 		}
 		if _, err := io.Copy(hash, file); err != nil {
-			file.Close()
+			closeErr := file.Close()
+			if closeErr != nil {
+				return "", fmt.Errorf("copy failed: %v (close failed: %v)", err, closeErr)
+			}
 			return "", err
 		}
-		file.Close()
+		if err := file.Close(); err != nil {
+			return "", fmt.Errorf("close failed for %s: %w", match, err)
+		}
 		_, _ = hash.Write([]byte{0})
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func validateSafeRelativePath(path string) error {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return fmt.Errorf("path is empty")
+	}
+
+	clean := filepath.Clean(trimmed)
+	if filepath.IsAbs(clean) {
+		return fmt.Errorf("absolute paths are not allowed")
+	}
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("path must stay within repository")
+	}
+
+	return nil
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -75,8 +75,8 @@ func TestValidateManifest_MissingFields(t *testing.T) {
 	data, _ := json.Marshal(manifest)
 	errs := ValidateManifest(data, mockCalculateChecksum(nil))
 
-	assertContains(t, errs, "Missing or invalid policy_version")
-	assertContains(t, errs, "Invalid updated_at format")
+	assertContains(t, errs, "missing or invalid policy_version")
+	assertContains(t, errs, "invalid updated_at format")
 	assertContains(t, errs, "Missing id")
 	assertContains(t, errs, "Missing path")
 	assertContains(t, errs, "Missing format")

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,153 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func mockCalculateChecksum(expectedChecksums map[string]string) func(string) (string, error) {
+	return func(pattern string) (string, error) {
+		if sum, ok := expectedChecksums[pattern]; ok {
+			return sum, nil
+		}
+		return "", fmt.Errorf("checksum for pattern %s not configured", pattern)
+	}
+}
+
+const testChecksum = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234"
+
+func validDataset() Dataset {
+	return Dataset{
+		ID:                  "test-dataset",
+		Path:                "test/path/*.csv",
+		Format:              "csv",
+		Source:              "example source",
+		SourceURL:           "http://example.com",
+		License:             "MIT",
+		VersionDate:         "2023-01-01",
+		Checksum:            testChecksum,
+		GenerationTimestamp: "2023-01-01T12:00:00Z",
+	}
+}
+
+func validManifest() Manifest {
+	return Manifest{
+		PolicyVersion: 1,
+		UpdatedAt:     "2026-03-08T12:00:00Z",
+		Datasets:      []Dataset{validDataset()},
+	}
+}
+
+func assertContains(t *testing.T, errs []error, contains string) {
+	t.Helper()
+	for _, err := range errs {
+		if strings.Contains(err.Error(), contains) {
+			return
+		}
+	}
+	t.Fatalf("expected error containing %q, got: %v", contains, errs)
+}
+
+func TestValidateManifest_Valid(t *testing.T) {
+	manifest := validManifest()
+	data, _ := json.Marshal(manifest)
+
+	errs := ValidateManifest(data, mockCalculateChecksum(map[string]string{
+		"test/path/*.csv": testChecksum,
+	}))
+
+	if len(errs) > 0 {
+		t.Fatalf("Expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateManifest_MissingFields(t *testing.T) {
+	manifest := Manifest{
+		UpdatedAt: "not-a-date",
+		Datasets: []Dataset{
+			{
+				// Intentionally sparse to assert strict required fields.
+			},
+		},
+	}
+	data, _ := json.Marshal(manifest)
+	errs := ValidateManifest(data, mockCalculateChecksum(nil))
+
+	assertContains(t, errs, "Missing or invalid policy_version")
+	assertContains(t, errs, "Invalid updated_at format")
+	assertContains(t, errs, "Missing id")
+	assertContains(t, errs, "Missing path")
+	assertContains(t, errs, "Missing format")
+	assertContains(t, errs, "Missing source")
+	assertContains(t, errs, "Missing source_url")
+	assertContains(t, errs, "Missing license")
+	assertContains(t, errs, "Missing version_date")
+	assertContains(t, errs, "Invalid checksum")
+	assertContains(t, errs, "Missing generation_timestamp")
+}
+
+func TestValidateManifest_InvalidDate(t *testing.T) {
+	manifest := validManifest()
+	manifest.Datasets[0].GenerationTimestamp = "2023-01-01" // Not RFC3339
+
+	data, _ := json.Marshal(manifest)
+	errs := ValidateManifest(data, mockCalculateChecksum(map[string]string{
+		"test/path/*.csv": testChecksum,
+	}))
+
+	if len(errs) != 1 {
+		t.Fatalf("Expected 1 error, got: %v", errs)
+	}
+	if !strings.Contains(errs[0].Error(), "Invalid generation_timestamp format") {
+		t.Errorf("Unexpected error message: %v", errs[0])
+	}
+}
+
+func TestValidateManifest_ChecksumMismatch(t *testing.T) {
+	manifest := validManifest()
+	data, _ := json.Marshal(manifest)
+	errs := ValidateManifest(data, mockCalculateChecksum(map[string]string{
+		"test/path/*.csv": "differentchecksum",
+	}))
+
+	if len(errs) != 1 {
+		t.Fatalf("Expected 1 error, got: %v", errs)
+	}
+	if !strings.Contains(errs[0].Error(), "Checksum mismatch") {
+		t.Errorf("Unexpected error message: %v", errs[0])
+	}
+}
+
+func TestValidateManifest_DuplicateDatasetID(t *testing.T) {
+	ds1 := validDataset()
+	ds2 := validDataset()
+	ds2.Path = "another/path/*.csv"
+
+	manifest := Manifest{
+		PolicyVersion: 1,
+		UpdatedAt:     "2026-03-08T12:00:00Z",
+		Datasets:      []Dataset{ds1, ds2},
+	}
+	data, _ := json.Marshal(manifest)
+
+	errs := ValidateManifest(data, mockCalculateChecksum(map[string]string{
+		ds1.Path: testChecksum,
+		ds2.Path: testChecksum,
+	}))
+
+	assertContains(t, errs, "Duplicate id")
+}
+
+func TestValidateManifest_InvalidVersionDate(t *testing.T) {
+	manifest := validManifest()
+	manifest.Datasets[0].VersionDate = "2023/01/01"
+
+	data, _ := json.Marshal(manifest)
+	errs := ValidateManifest(data, mockCalculateChecksum(map[string]string{
+		"test/path/*.csv": testChecksum,
+	}))
+
+	assertContains(t, errs, "Invalid version_date format")
+}

--- a/scripts/generate_registry.sh
+++ b/scripts/generate_registry.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scripts generates the IBAN registry
+echo "Downloading SWIFT IBAN registry..."
+go run gen/cmd/download.go
+
+echo "Regenerating internal/countrymeta/registry.go..."
+go generate ./internal/countrymeta
+
+echo "Updating manifest..."
+# This is a bit tricky to do purely in bash, better to just let users know
+echo "Please remember to update datasets/manifest.json with new checksums if datasets/iban-registry.txt has changed."
+
+echo "Done."


### PR DESCRIPTION
## Summary
This PR delivers Objective 02 (Dataset Governance and Provenance) by introducing strict manifest validation, deterministic generation improvements, and machine-readable drift reporting, with additional security hardening for filesystem access patterns.

## Changes
- Added manifest validation CLI and core validator:
  - `cmd/manifest/main.go`
  - `internal/manifest/manifest.go`
  - `internal/manifest/manifest_test.go`
- Enforced manifest policy checks:
  - required dataset fields (`id`, `path`, `format`, `source`, `source_url`, `license`, `version_date`, `checksum`, `generation_timestamp`)
  - `policy_version` and `updated_at` validation
  - duplicate dataset ID detection
  - checksum shape validation (SHA-256 hex)
  - checksum verification against actual files
- Added dataset drift reporting utility:
  - `cmd/drift/main.go`
  - `internal/drift/drift.go`
  - `internal/drift/drift_test.go`
- Integrated manifest validation into CI (`.github/workflows/test.yml`).
- Updated provenance metadata in `datasets/manifest.json`:
  - added `source_url` and `generation_timestamp`
  - replaced placeholders with concrete checksums
  - normalized `updated_at` to RFC3339
- Hardened IBAN metadata codegen output determinism by formatting generated Go source in `gen/ibanmeta/ibanmeta.go`.
- Added `scripts/generate_registry.sh` and updated `docs/development.md` with regeneration + validation flow.

## Security Hardening
- Restricted manifest/drift file inputs to sanitized repository-relative paths before file reads/opens.
- Added explicit path validation for checksum glob patterns and resolved matches.
- Handled file close errors explicitly in checksum calculation logic.
- Tightened drift report output permissions from `0644` to `0600`.

## Verification
Executed locally:
- `./scripts/check_repo_docs.sh`
- `go run cmd/manifest/main.go datasets/manifest.json`
- `go test ./...`
- `$(go env GOPATH)/bin/gosec ./cmd/drift ./cmd/manifest ./internal/drift ./internal/manifest ./gen/ibanmeta`

All passed (`gosec Issues: 0`).
